### PR TITLE
Support right-to-left languages

### DIFF
--- a/Classes/UIImage+GKContact.m
+++ b/Classes/UIImage+GKContact.m
@@ -78,7 +78,8 @@ static inline NSString *GKContactKey(NSString *initials, CGSize size, UIColor *b
     NSDictionary *dict = @{NSFontAttributeName: font, NSForegroundColorAttributeName: textColor};
     CGSize textSize = [initials sizeWithAttributes:dict];
 
-    [initials drawInRect:CGRectMake(r - textSize.width / 2, r - font.lineHeight / 2, w, h) withAttributes:dict];
+    NSInteger xFactor = [UIApplication sharedApplication].userInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft ? -1 : 1;
+    [initials drawInRect:CGRectMake(xFactor * (r - textSize.width / 2), r - font.lineHeight / 2, w, h) withAttributes:dict];
 
     UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
 


### PR DESCRIPTION
Hi,

Currently, the example app works like this in right-to-left languages like Arabic:

![screen shot 2018-09-19 at 14 13 13](https://user-images.githubusercontent.com/28537210/45752944-620ba480-bc17-11e8-9ba0-bc0b95073945.png)

To reproduce the issue, enable Arabic in Project Settings > Info > Localizations, and change the device language to Arabic.

It appears that the origin of the coordinates system is set in the upper-right corner for this languages, so the string is rendered outside the circle. With the code in this pull request, the issue is fixed.

Let me know if should I change something else. Thank you for your time.